### PR TITLE
Implement searching

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,6 +1,25 @@
-# Fixes and quick features shortlist
+# Fixes and quick features shortlist before first release
+
+## Priority
+
+- [ ] Fix scrolling past first
+- [ ] Fix scrolling past last shown
+- [ ] Print line numbers
+- [ ] Fix filter list cursor y coordinate for more filters than overlay can fit
+- [ ] Allow logging in the background
+- [ ] Fix scrolling multiple lines when text is wrapped
+
+## Less priority
 
 - [ ] Esc cancels filter changes, both single line and whole view
+- [ ] printing search matches count and position
+- [ ] allow commands (:) with filter view
+- [ ] send event description to status line/log on user actions (e.g. Filter disabled, filter negated etc)
+- [ ] Print active filters on status line
+- [ ] Use plaintext patterns by default. With easy promotion to regex.
+
+## Hall of fame
+
 - [x] toggle word wrap
 - [x] horizontal movement with arrows
 - [x] render cursor in command input mode
@@ -8,21 +27,13 @@
 - [x] fix horizontal scrolling filtered text
 - [x] rendering filtering list
 - [x] applying multiple filters
-- [ ] search + navigation (next/previous)
-- [ ] printing search matches count and position
-- [ ] allow logging in the background
+- [x] search + navigation (next/previous)
 - [x] add mouse scroll support
 - [x] faster mouse scrolling
 - [x] print current line in status
 - [x] add home/end support
 - [x] ease use of commands: trim whitespace, allow immediate value after whitespace
-- [ ] fix scrolling past last shown when filtered
-- [ ] fix scrolling multiple lines when text is wrapped
 - [x] hierarchical app state and event/input processing
-- [ ] more performant text navigation - full log shouldn't be processed on every key stroke.
-- [ ] remove status/error prompt on :
-- [ ] allow commands (:) with filter view
-- [ ] send event description to status line/log on user actions (e.g. Filter disabled, filter negated etc)
-- [ ] placeholder text for empty filter list (press a to add new filter...)
-- [ ] Fix filter list cursor y coordinate for more filters than overlay can fit
-- [ ] Print active filters on status line
+- [x] more performant text navigation - full log shouldn't be processed on every key stroke.
+- [x] remove status/error prompt on :
+- [x] placeholder text for empty filter list (press a to add new filter...)

--- a/src/bin/sherlog_tui/status_line.rs
+++ b/src/bin/sherlog_tui/status_line.rs
@@ -32,6 +32,10 @@ impl StatusLine {
     pub fn enter_highlight_pattern_mode(&mut self, value: String) {
         self.content = StatusLineContent::SearchPattern(SearchKind::Highlight, value);
     }
+
+    pub fn enter_search_mode(&mut self, value: String) {
+        self.content = StatusLineContent::SearchPattern(SearchKind::Search, value);
+    }
 }
 
 impl<'a> Render<'a> for StatusLine {
@@ -83,6 +87,9 @@ impl<'a> React<'a> for StatusLine {
                 StatusLineContent::SearchPattern(SearchKind::Highlight, s) => {
                     Some(StatusLineReaction::Highlight(s.clone()))
                 }
+                StatusLineContent::SearchPattern(SearchKind::Search, s) => {
+                    Some(StatusLineReaction::Search(s.clone()))
+                }
                 _ => Some(StatusLineReaction::Defocus),
             },
             _ => None,
@@ -99,18 +106,20 @@ pub enum StatusLineReaction {
     Defocus,
     ExecuteCommand(String),
     Highlight(String),
+    Search(String),
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum SearchKind {
     Highlight,
-    // More to follow
+    Search,
 }
 
 impl SearchKind {
     pub fn as_str(&self) -> &'static str {
         match self {
             SearchKind::Highlight => "highlight",
+            SearchKind::Search => "search",
         }
     }
 }

--- a/src/bin/sherlog_tui/text_area.rs
+++ b/src/bin/sherlog_tui/text_area.rs
@@ -7,62 +7,27 @@ use crate::ty::Render;
 
 pub(crate) struct TextArea {
     pub x: usize,
-    pub y: usize,
-    pub max_y: usize,
     pub height: u16, // Shouldn't we get this as render feedback?
     pub wrap: bool,
     pub lines: Vec<TextLine>,
 }
 
 impl TextArea {
-    pub fn new(height: u16, max_y: usize) -> Self {
+    pub fn new(height: u16) -> Self {
         TextArea {
             x: 0,
-            y: 0,
-            max_y,
             height,
             wrap: false,
             lines: vec![],
         }
     }
 
-    pub fn scroll_up(&mut self, line_cnt: usize) -> bool {
-        let old_y = self.y;
-        self.y = self.y.saturating_sub(line_cnt);
-        old_y != self.y
-    }
-
-    pub fn scroll_down(&mut self, line_cnt: usize) -> bool {
-        let old_y = self.y;
-        self.y = self.y.saturating_add(line_cnt);
-        if self.y > self.max_y {
-            self.y = self.max_y;
-        }
-        old_y != self.y
-    }
-
-    pub fn scroll_left(&mut self) -> bool {
-        let old_x = self.x;
+    pub fn scroll_left(&mut self) {
         self.x = self.x.saturating_sub(1);
-        old_x != self.x
     }
 
-    pub fn scroll_right(&mut self) -> bool {
-        let old_x = self.x;
+    pub fn scroll_right(&mut self) {
         self.x = self.x.saturating_add(1);
-        old_x != self.x
-    }
-
-    pub fn go_top(&mut self) -> bool {
-        let old_y = self.y;
-        self.y = 0;
-        old_y != self.y
-    }
-
-    pub fn go_bottom(&mut self) -> bool {
-        let old_y = self.y;
-        self.y = self.max_y;
-        old_y != self.y
     }
 
     fn make_spans(line: &TextLine, offset: usize) -> tui::text::Spans<'_> {
@@ -96,6 +61,14 @@ impl TextArea {
     pub fn toggle_wrap(&mut self) -> bool {
         self.wrap = !self.wrap;
         self.wrap
+    }
+
+    pub fn first_line(&self) -> Option<&TextLine> {
+        self.lines.first()
+    }
+
+    pub fn last_line(&self) -> Option<&TextLine> {
+        self.lines.last()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,8 +57,12 @@ impl Sherlog {
     }
 
     //TODO: consider changing api to iterator
-    pub fn get_line_with_search_results(&self, start: usize) -> Option<usize> {
+    pub fn next_search_result(&self, start: usize) -> Option<usize> {
         self.index_search.range(start..).next().map(|i| *i.0)
+    }
+
+    pub fn prev_search_result(&self, start: usize) -> Option<usize> {
+        self.index_search.range(..start + 1).last().map(|i| *i.0)
     }
 
     pub fn highlight(&mut self, highlight: Option<Regex>) {
@@ -139,9 +143,14 @@ mod test {
         let data = "line1\nline2\nline3\n";
         let mut sherlog = Sherlog::new(data);
         sherlog.search(Regex::new("line2").unwrap());
-        assert_eq!(sherlog.get_line_with_search_results(0), Some(1));
-        assert_eq!(sherlog.get_line_with_search_results(1), Some(1));
-        assert_eq!(sherlog.get_line_with_search_results(2), None);
-        assert_eq!(sherlog.get_line_with_search_results(3), None);
+        assert_eq!(sherlog.next_search_result(0), Some(1));
+        assert_eq!(sherlog.next_search_result(1), Some(1));
+        assert_eq!(sherlog.next_search_result(2), None);
+        assert_eq!(sherlog.next_search_result(3), None);
+
+        assert_eq!(sherlog.prev_search_result(3), Some(1));
+        assert_eq!(sherlog.prev_search_result(2), Some(1));
+        assert_eq!(sherlog.prev_search_result(1), Some(1));
+        assert_eq!(sherlog.prev_search_result(0), None);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 mod ty;
 
+use std::collections::BTreeMap;
+
 pub use regex::Regex;
 pub use ty::filter::RegexFilter;
 pub use ty::span::{SpanKind, SpanRef};
@@ -9,18 +11,20 @@ pub struct Sherlog {
     lines: Vec<String>,
     filters: Vec<RegexFilter>,
     highlight: Option<Regex>,
-    index_filtered: LineIndex,
+    index_filtered: Vec<usize>,
+    index_search: BTreeMap<usize, Vec<(u32, u32)>>,
 }
 
 impl Sherlog {
     pub fn new(text: &str) -> Self {
         let lines: Vec<_> = text.lines().map(String::from).collect();
-        let index_filtered = LineIndex((0..lines.len()).collect());
+        let index_filtered = (0..lines.len()).collect();
         Sherlog {
             lines,
             filters: Vec::new(),
             highlight: None,
             index_filtered,
+            index_search: BTreeMap::new(),
         }
     }
 
@@ -33,7 +37,28 @@ impl Sherlog {
             .filter(|(_, line)| self.filters.iter().all(|pat| pat.is_match(line)))
             .map(|(n, _)| n)
             .collect();
-        self.index_filtered = LineIndex(filtered_lines);
+        self.index_filtered = filtered_lines;
+    }
+
+    pub fn search(&mut self, pattern: Regex) {
+        // Builds search results index
+        self.index_search = BTreeMap::new();
+        for (n, line) in self.lines.iter().enumerate() {
+            for found in pattern.find_iter(line) {
+                self.index_search
+                    .entry(n)
+                    .or_default()
+                    .push((found.start() as u32, found.end() as u32))
+            }
+        }
+        // For now we force highlight to search pattern as current API cannot handle overlapping search result
+        // and highlight. And we do want to mark search spans.
+        self.highlight = Some(pattern);
+    }
+
+    //TODO: consider changing api to iterator
+    pub fn get_line_with_search_results(&self, start: usize) -> Option<usize> {
+        self.index_search.range(start..).next().map(|i| *i.0)
     }
 
     pub fn highlight(&mut self, highlight: Option<Regex>) {
@@ -42,7 +67,6 @@ impl Sherlog {
 
     pub fn get_lines(&self, first: usize, cnt: Option<usize>) -> Vec<TextLineRef> {
         self.index_filtered
-            .0
             .iter()
             .skip(first)
             .take(cnt.unwrap_or(usize::MAX))
@@ -77,8 +101,6 @@ impl Sherlog {
     }
 }
 
-struct LineIndex(Vec<usize>);
-
 #[cfg(test)]
 mod test {
     use super::*;
@@ -88,12 +110,38 @@ mod test {
     }
 
     #[test]
-    fn provides_lines() {
-        let data = "line1\nline2\n";
+    fn can_provides_all_lines() {
+        let data = "line1\nline2\nline3\n";
         let sherlog = Sherlog::new(data);
         assert_eq!(
             as_strings(sherlog.get_lines(0, None)),
-            vec![String::from("line1"), String::from("line2")]
+            vec![
+                String::from("line1"),
+                String::from("line2"),
+                String::from("line3")
+            ]
         );
+    }
+
+    #[test]
+    fn can_filter() {
+        let data = "line1\nline2\nline3\n";
+        let mut sherlog = Sherlog::new(data);
+        sherlog.filter(vec!["line2".try_into().unwrap()]);
+        assert_eq!(
+            as_strings(sherlog.get_lines(0, None)),
+            vec![String::from("line2")]
+        );
+    }
+
+    #[test]
+    fn can_search() {
+        let data = "line1\nline2\nline3\n";
+        let mut sherlog = Sherlog::new(data);
+        sherlog.search(Regex::new("line2").unwrap());
+        assert_eq!(sherlog.get_line_with_search_results(0), Some(1));
+        assert_eq!(sherlog.get_line_with_search_results(1), Some(1));
+        assert_eq!(sherlog.get_line_with_search_results(2), None);
+        assert_eq!(sherlog.get_line_with_search_results(3), None);
     }
 }

--- a/src/ty/filter.rs
+++ b/src/ty/filter.rs
@@ -20,3 +20,11 @@ impl From<Regex> for RegexFilter {
         }
     }
 }
+
+impl TryFrom<&str> for RegexFilter {
+    type Error = regex::Error;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Regex::new(value).map(RegexFilter::from)
+    }
+}


### PR DESCRIPTION
Implement searching (reasonably efficiently this time)
Functionally similar to less.
Use / to start typing search pattern, after that n and shift+n navigates next/previous respectively. Does not hop between matches within a single line.